### PR TITLE
fix typo with .wvu-slash--#{$i}--up mixin

### DIFF
--- a/scss/utilities/_wvu-slash.scss
+++ b/scss/utilities/_wvu-slash.scss
@@ -89,7 +89,7 @@ $i: 1;
     }
     &.wvu-slash--#{$i}-up {
       &:before {
-        top: calc(-25% + -(#{$i} * #{$spacer})) $global-important;
+        top: calc(-25% - (#{$i} * #{$spacer})) $global-important;
       }
     }
     &.wvu-slash--#{$i}-down {


### PR DESCRIPTION
There is a typo in this mixin that causes some css minification to fail.  Assuming the typo also causes incorrect render.