### PR TITLE
Switch topo map background from PNG to SVG

### DIFF
--- a/scss/_wvu-variables.scss
+++ b/scss/_wvu-variables.scss
@@ -105,6 +105,7 @@ $wvu-grid-pattern-zoomed: "https://static.wvu.edu/global/images/patterns/wvu/bac
 $wvu-grid-pattern-zoomed-transparent: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-zoomed-transparent--1.0.0.svg";
 $wvu-topo-map-black: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-black-transparent--1.0.0.png";
 $wvu-topo-map-white: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-white-transparent--1.0.0.png";
+$wvu-topo-map-opacity: 0.1 !default;
 
 // Make !important configurable
 $global-important: !important !default; // Set to `null` to remove !important from all CSS property values, except where explicitly defined otherwise in mixin @includes.

--- a/scss/_wvu-variables.scss
+++ b/scss/_wvu-variables.scss
@@ -103,8 +103,8 @@ $wvu-grid-pattern: "https://static.wvu.edu/global/images/patterns/wvu/background
 $wvu-grid-pattern-transparent: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-transparent--1.0.0.svg";
 $wvu-grid-pattern-zoomed: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-zoomed--1.0.0.svg";
 $wvu-grid-pattern-zoomed-transparent: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-zoomed-transparent--1.0.0.svg";
-$wvu-topo-map-black: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-black-transparent--1.0.0.png";
-$wvu-topo-map-white: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-white-transparent--1.0.0.png";
+$wvu-topo-map-black: "http://static.wvu.edu/global/images/patterns/wvu/background__topo-black--1.0.0.svg";
+$wvu-topo-map-white: "http://static.wvu.edu/global/images/patterns/wvu/background__topo-white--1.0.0.svg";
 $wvu-topo-map-opacity: 0.1 !default;
 
 // Make !important configurable

--- a/scss/mixins/_wvu-bg-pattern.scss
+++ b/scss/mixins/_wvu-bg-pattern.scss
@@ -135,6 +135,7 @@
       background-image: url($wvu-topo-map-black);
       background-position: center;
       background-size: cover;
+      opacity: $wvu-topo-map-opacity;
       bottom: 0;
       content: '';
       left: 0;
@@ -151,6 +152,7 @@
       background-image: url($wvu-topo-map-white);
       background-position: center;
       background-size: cover;
+      opacity: $wvu-topo-map-opacity;
       bottom: 0;
       content: '';
       left: 0;


### PR DESCRIPTION
The PNG files were large in size, upwards of 300k. This switch drops this heavy weight dependency down to a much more manageable 90k after gzipping from AWS S3/Cloudfront serve.