### PR TITLE
fix http links to https for topo maps

### DIFF
--- a/scss/_wvu-variables.scss
+++ b/scss/_wvu-variables.scss
@@ -103,8 +103,8 @@ $wvu-grid-pattern: "https://static.wvu.edu/global/images/patterns/wvu/background
 $wvu-grid-pattern-transparent: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-transparent--1.0.0.svg";
 $wvu-grid-pattern-zoomed: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-zoomed--1.0.0.svg";
 $wvu-grid-pattern-zoomed-transparent: "https://static.wvu.edu/global/images/patterns/wvu/background__grid-zoomed-transparent--1.0.0.svg";
-$wvu-topo-map-black: "http://static.wvu.edu/global/images/patterns/wvu/background__topo-black--1.0.0.svg";
-$wvu-topo-map-white: "http://static.wvu.edu/global/images/patterns/wvu/background__topo-white--1.0.0.svg";
+$wvu-topo-map-black: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-black--1.0.0.svg";
+$wvu-topo-map-white: "https://static.wvu.edu/global/images/patterns/wvu/background__topo-white--1.0.0.svg";
 $wvu-topo-map-opacity: 0.1 !default;
 
 // Make !important configurable


### PR DESCRIPTION
The topo maps svgs where added as as http urls.  This fixes them as https