### PR TITLE
Make the Stat Sheet component use an h2 by default.

### DIFF
--- a/views/components/_wvu-stat-sheet.html
+++ b/views/components/_wvu-stat-sheet.html
@@ -38,12 +38,12 @@
           </small>
           <span class="d-inline-block badge badge-primary mb-1">Header</span>
         </r:edit_mode_only>
-        <r:comment><!-- For the h1, apply an ID that will tell screanreaders to use this element as the label for the section. Also apply classes to the header. If supplied by user, use those. If not use default. --></r:comment>
-        <h1 id="<r:var name="componentName" />-label" class="<r:page:if_has_content_for region="{$headerClasses}"><r:page:content name="{$headerClasses}" /></r:page:if_has_content_for><r:page:unless_has_content_for region="{$headerClasses}"><r:yield name="{$defaultHeaderClasses}"><r:content /></r:yield></r:page:unless_has_content_for>">
+        <r:comment><!-- For the h2, apply an ID that will tell screanreaders to use this element as the label for the section. Also apply classes to the header. If supplied by user, use those. If not use default. --></r:comment>
+        <h2 id="<r:var name="componentName" />-label" class="<r:page:if_has_content_for region="{$headerClasses}"><r:page:content name="{$headerClasses}" /></r:page:if_has_content_for><r:page:unless_has_content_for region="{$headerClasses}"><r:yield name="{$defaultHeaderClasses}"><r:content /></r:yield></r:page:unless_has_content_for>">
           <r:editable_region name="{$componentHeader}" scope="{$componentScope}" type="simple">
             Estimate your scholarships.
           </r:editable_region>
-        </h1>
+        </h2>
         <r:comment><!-- This is just a label for the editable region that follows in order to make it clear to content editors what the region is for (in case they delete content and forget). --></r:comment>
         <r:edit_mode_only><span class="d-inline-block badge badge-primary mb-1">Main Content</span></r:edit_mode_only>
         <r:comment><!-- Editable region for main content. --></r:comment>


### PR DESCRIPTION
In a couple different ConceptBoard reviews, users had implemented this component with a backpage header. The backpage header component uses an h1 by default. 

IMO it's better to have this component use an h2 by default, that way it can be combined with other components. If the component needs to use an `h1`, we can do that on a per page basis and likely [use JS](https://stackoverflow.com/questions/240467/how-do-i-change-an-element-e-g-h1-h2-using-jquery-plain-old-javascript#240494) or just copy this partial into the theme and customize it.