### PR TITLE
Add Title field as a field that can override the title tag in the `<head>`.

### DIFF
--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -7,7 +7,7 @@
       <link rel="canonical" href="https://<r:site:domain />">
     </r:page:if_site_default>
     <r:page:unless_site_default>
-      <title><r:page:first_non_blank_attr names="alternate_name, name" /> | <r:site_name /> | West Virginia University</title>
+      <title><r:page:first_non_blank_attr names="title, alternate_name, name" /> | <r:site_name /> | West Virginia University</title>
       <link rel="canonical" href="<r:page:url />" >
     </r:page:unless_site_default>
     <meta name="description" content="<r:page:meta_description />" />


### PR DESCRIPTION
With this change, users will be able to enter a string into the "Title" field in Page Properties and see that reflected in the `<title>` tag in the `<head>`. 

![CleanSlate Page Properties showing the Title field](https://user-images.githubusercontent.com/575865/88408182-315f9d80-cda1-11ea-999a-576409b35ac9.png)
