### PR TITLE
Replace Sass division symbol (`/`) with multiplication for better forward compatibility

### DIFF
--- a/scss/custom/_nav.scss
+++ b/scss/custom/_nav.scss
@@ -17,6 +17,6 @@
     font-size: $small-font-size;
     font-weight: $font-weight-normal;
     list-style-type: none;
-    padding-left: $spacer / 2;
+    padding-left: $spacer * 0.5;
   }
 }

--- a/scss/custom/_wvu-calendar-widget.scss
+++ b/scss/custom/_wvu-calendar-widget.scss
@@ -6,7 +6,7 @@
 
 .wvu-calendar {
   padding-left: 0;
-  li { margin-bottom: $spacer / 4; display: inline-block; width: 100%;
+  li { margin-bottom: $spacer * 0.25; display: inline-block; width: 100%;
     .eventDate { float: left; margin-right: 4%; width: 10%; text-align: center; padding-bottom: 6px; border-radius: 6px; display: inline-block;
     }
     .eventMonth { font-size: .8em; text-transform: uppercase; }
@@ -54,7 +54,7 @@
 }
 
 .wvu-calendar-widget__item {
-  margin-bottom: $spacer / 2;
+  margin-bottom: $spacer * 0.5;
 }
 
 .wvu-calendar-widget__day {
@@ -62,7 +62,7 @@
 }
 
 .wvu-calendar-widget { padding-left: 0;
-  li { margin-bottom: $spacer / 4; display: inline-block; width: 100%;
+  li { margin-bottom: $spacer * 0.25; display: inline-block; width: 100%;
     .eventDate { float: left; margin-right: 4%; width: 10%; text-align: center; padding-bottom: 6px; border-radius: 6px;
     }
     .calEventMonth { font-size: .8em; text-transform: uppercase; }
@@ -81,7 +81,7 @@
     flex-flow: row wrap;
     li {
       width: 33%;
-      padding: 0 0 $spacer / 2 0;
+      padding: 0 0 ($spacer * 0.5) 0;
       vertical-align: top;
     }
   }

--- a/scss/utilities/_wvu-bg-position.scss
+++ b/scss/utilities/_wvu-bg-position.scss
@@ -62,7 +62,7 @@ $i: 100;
                                     (xl, $wvu-bp-xl) {
       .wvu-bg-position-#{$bp-value}-#{$bg-class}--#{$i} {
         @media (min-width: $breakpoint) {
-          background-position: $bg-property round(percentage($i/100)) $global-important;
+          background-position: $bg-property round(percentage($i * 0.01)) $global-important;
         }
       }
     }


### PR DESCRIPTION
![Dart Sass division warning terminal screenshot](https://user-images.githubusercontent.com/575865/160166746-dcf8f1b3-7fa9-4121-bbf0-6a049b7935a3.png)

If you use Dart Sass to compile the Design System's Sass files, Dart Sass throws depreciation warnings about the `/` symbol. They advise us to use a new `math.div()` function or `calc()` to solve these warnings. Since we're not doing any hard math, simple multiplication seems like the best fix.

This change doesn't change any actual CSS, just the Sass. It should be good to merge.

Related to #273.

Also, Bootstrap used the `/` symbol [up until v4.6.1](https://github.com/twbs/bootstrap/pull/34571). So, if you're looking to use Dart Sass with Bootstrap, it'd be a good idea to pull in the latest version of Bootstrap. FWIW, I use the latest version of Bootstrap v4.x.x on all my projects and have noticed zero regressions.

If there is no activity on this PR by 4/1/22, I will merge this PR myself.