### PR TITLE
Defer non-critical CSS (FontAwesome).

### DIFF
--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -33,7 +33,13 @@
     <meta name="twitter:description" content="<r:page:meta_description />">
 
     <r:include_stylesheet name="styles" />
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+    <r:comment>
+      <!-- NOTE: Defer non-critical CSS: https://web.dev/defer-non-critical-css/ -->
+    </r:comment>
+    <link rel="preload" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" as="style" onload="this.onload=null;this.rel='stylesheet'" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+    <noscript>
+      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+    </noscript>
 
   </head>
 


### PR DESCRIPTION
This fixes "Eliminate render blocking resources" in Lighthouse when running a performance audit. See [Defer non-critical CSS](https://web.dev/defer-non-critical-css/) on Web.dev for more information about this technique.

Related to #303. Be sure to use the appropriate CDN/Link tag when merging these two PRs.

If there is no activity on this PR by 4/1/22, I will merge this PR myself.

___________________

In the future, it'd be a good idea to not include FontAwesome's CSS or JS and just embed the SVG directly into the HTML. This avoids any CSS & JS overhead and is styleable with your current CSS. [More background about that](https://css-tricks.com/icon-fonts-vs-svg/).