### PR TITLE
Update FontAwesome version to v5.15.4.

### DIFF
--- a/views/layouts/default.html
+++ b/views/layouts/default.html
@@ -33,7 +33,14 @@
     <meta name="twitter:description" content="<r:page:meta_description />">
 
     <r:include_stylesheet name="styles" />
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+
+    <r:comment>
+      <!-- NOTE: Defer non-critical CSS: https://web.dev/defer-non-critical-css/ -->
+    </r:comment>
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4=" crossorigin="anonymous">
+    <noscript>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css" integrity="sha256-mUZM63G8m73Mcidfrv5E+Y61y7a12O5mW4ezU3bxqW4=" crossorigin="anonymous">
+    </noscript>
 
   </head>
 


### PR DESCRIPTION
This PR also follows the best practices outlined in #303 and #304.

I had thought about updating to the latest v6.1.1 in this PR, but realized changing any classes in shared partials might break other people's themes. 

FWIW, here's how the FontAwesome classes have changed in v6:

| Version 5 | Version 6 | Example |
|-----------|------------|----------------------------------------------------|
| fab          | fa-brands  | &lt;i class="fa-brands fa-bootstrap"&gt;&lt;/i&gt; |
| fad          | fa-duotone | &lt;i class="fa-duotone fa-user"&gt;&lt;/i&gt;     |
| fal           | fa-light   | &lt;i class="fa-light fa-user"&gt;&lt;/i&gt;       |
| far           | fa-regular | &lt;i class="fa-regular fa-user"&gt;&lt;/i&gt;     |
| fas           | fa-solid   | &lt;i class="fa-solid fa-user"&gt;&lt;/i&gt;       |
| &nbsp;    | fa-thin    | &lt;i class="fa-thin fa-user"&gt;&lt;/i&gt;        |
